### PR TITLE
Support autocomplete response

### DIFF
--- a/adgangsadresser.go
+++ b/adgangsadresser.go
@@ -3,9 +3,10 @@ package dawa
 import (
 	"bufio"
 	"encoding/csv"
-	"github.com/ugorji/go/codec"
 	"io"
 	"strconv"
+
+	"github.com/ugorji/go/codec"
 )
 
 // En adgangsadresse er en struktureret betegnelse som angiver en særskilt
@@ -35,6 +36,17 @@ type AdgangsAdresse struct {
 	SupplerendeBynavn string              `json:"supplerendebynavn"` // Et supplerende bynavn – typisk landsbyens navn – eller andet lokalt stednavn, der er fastsat af kommunen for at præcisere adressens beliggenhed indenfor postnummeret.
 	Vejstykke         VejstykkeRef        `json:"vejstykke"`         // Vejstykket som adressen er knyttet til.
 	Zone              string              `json:"zone"`              // Hvilken zone adressen ligger i. "Byzone", "Sommerhusområde" eller "Landzone". Beregnes udfra adgangspunktet og zoneinddelingerne fra PlansystemDK
+
+	// Fields returned in autocomplete
+	Text                string `json:"tekst"`
+	AutocompleteAddress `json:"adgangsadresse"`
+}
+
+type AutocompleteAddress struct {
+	Street     string `json:"vejnavn"`
+	Husnr      string `json:"husnr"`
+	PostNumber string `json:"postnr"`
+	PostName   string `json:"postnrnavn"`
 }
 
 // Adressens placering i Det Danske Kvadratnet (DDKN).

--- a/adressequery_test.go
+++ b/adressequery_test.go
@@ -25,7 +25,7 @@ func TestAddresseQueryParameters(t *testing.T) {
 		t.Fatal("Unable to find expected field 'postnr'")
 	}
 	if len(param) != 1 {
-		t.Fatal("Number of parameters expected to be 1, was %d", len(param))
+		t.Fatalf("Number of parameters expected to be 1, was %d", len(param))
 	}
 	expect := `|1234|abcdef|æøå|"?!"#¤=%&|&|234.0|"abc"`
 	if param[0] != expect {

--- a/listquery_test.go
+++ b/listquery_test.go
@@ -18,7 +18,7 @@ func TestListQueryParameters(t *testing.T) {
 		t.Fatal("Unable to find expected field 'kode'")
 	}
 	if len(param) != 1 {
-		t.Fatal("Number of parameters expected to be 1, was %d", len(param))
+		t.Fatalf("Number of parameters expected to be 1, was %d", len(param))
 	}
 	expect := `|1234|abcdef|æøå|"?!"#¤=%&|&|234.0|"abc"`
 	if param[0] != expect {
@@ -50,15 +50,14 @@ var ListURL = []qb{
 	qb{NewListQuery("regioner", true).URL(), DefaultHost + "/regioner/autocomplete"},
 
 	// Test params
-	qb{NewListQuery("regioner", false).Q(singleParam).URL(), DefaultHost + "/regioner?q="+ singleEncoded+""},
-	qb{NewListQuery("regioner", false).Kode(multiParam...).URL(), DefaultHost + "/regioner?kode="+ multiEncoded+""},
-	qb{NewListQuery("regioner", false).Navn(singleParam).URL(), DefaultHost + "/regioner?navn="+ singleEncoded+""},
+	qb{NewListQuery("regioner", false).Q(singleParam).URL(), DefaultHost + "/regioner?q=" + singleEncoded + ""},
+	qb{NewListQuery("regioner", false).Kode(multiParam...).URL(), DefaultHost + "/regioner?kode=" + multiEncoded + ""},
+	qb{NewListQuery("regioner", false).Navn(singleParam).URL(), DefaultHost + "/regioner?navn=" + singleEncoded + ""},
 	qb{NewListQuery("regioner", false).NoFormat().URL(), DefaultHost + "/regioner?noformat="},
 
 	// Test multiparam
 	qb{NewListQuery("regioner", false).Q(singleParam).Kode(multiParam...).Navn(singleParam).NoFormat().URL(),
-					DefaultHost + "/regioner?q="+ singleEncoded+"&kode="+ multiEncoded+"&navn="+ singleEncoded+"&noformat="},
-
+		DefaultHost + "/regioner?q=" + singleEncoded + "&kode=" + multiEncoded + "&navn=" + singleEncoded + "&noformat="},
 }
 
 func TestListQueryURL(t *testing.T) {


### PR DESCRIPTION
We have different response from
http://dawa.aws.dk/adgangsadresser/autocomplete?q=Kronprinsensvej
then all other apis.
```
{
    "tekst": "Kronprinsensvej 1, 3480 Fredensborg",
    "adgangsadresse": {
      "id": "0a3f507e-b0ae-32b8-e044-0003ba298018",
      "href": "http://dawa.aws.dk/adgangsadresser/0a3f507e-b0ae-32b8-e044-0003ba298018",
      "vejnavn": "Kronprinsensvej",
      "husnr": "1",
      "supplerendebynavn": null,
      "postnr": "3480",
      "postnrnavn": "Fredensborg",
      "stormodtagerpostnr": null,
      "stormodtagerpostnrnavn": null
    }
  }
```